### PR TITLE
Cover page for the ACCU 2019 conference

### DIFF
--- a/pages/2019/accu2019.adoc
+++ b/pages/2019/accu2019.adoc
@@ -1,0 +1,25 @@
+////
+.. title: ACCU 2019
+.. type: text
+////
+
+
+ACCU 2019 took place at
+http://www.marriott.co.uk/hotels/travel/brsdt-bristol-marriott-hotel-city-centre/[Bristol Marriott Hotel
+City Centre] 2019-04-09 to 2019-04-13 – Tuesday 2019-04-09, the first day was, as ever, some full day workshops; the
+conference ran from Wednesday 2019-04-10 to, and including, Saturday 2019-04-13.
+
+There are various webpages acting as a record of the conference:
+
+* link:keynotes.html[The details of the keynotes.]
+* link:schedule.html[The schedule as happened.]
+* link:sessions.html[Blurbs of the sessions.]
+* link:presenters.html[Bios of the presenters.]
+* link:sponsors_and_exhibitors.html[Logos of the sponsors.]
+* link:attender_reports.html[Various conference reports by attenders that have been notified or discovered.]
+* link:prices.html[Conference prices]
+
+The schedule webpage contains links to videos on ACCU YouTube channel and PDFs of slides where these have
+been notofied/collected.
+
+The ACCUConf YouTube channel is https://www.youtube.com/channel/UCJhay24LTpO1s4bIZxuIqKw[here].


### PR DESCRIPTION
Adding the missing cover page for the ACCU 2019 conference (#194). Not tested, though.